### PR TITLE
Added to_handler command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -38,7 +38,29 @@ module Msf
         def commands
           super.update({
             "generate" => "Generates a payload",
+            "to_handler" => "Creates a handler with the specified payload"
           })
+        end
+
+        def cmd_to_handler(*args)
+          handler = framework.modules.create('exploit/multi/handler')
+
+          handler_opts = {
+            'Payload'        => mod.refname, #mod.fullname,
+            'LocalInput'     => driver.input,
+            'LocalOutput'    => driver.output,
+            'ExitOnSession'  => false,
+            'RunAsJob'       => true
+          }
+          
+          #handler.datastore.reverse_merge!(mod.datastore)
+          handler.datastore.merge!(mod.datastore)
+          handler.exploit_simple(handler_opts)
+          job_id = handler.job_id
+
+          print_status "Payload Handler Started as Job #{job_id}"
+
+
         end
 
         #


### PR DESCRIPTION
This commit adds a "to_handler" command to msfconsole when "using" a payload.

After generating a payload from msfconsole, we needed to set multi/handler and the payload with the same param as we used to generate it. That was really boring...
The to_handler command creates the handler as a job and sets the payload and the options for it.

### Example Output:





```
msf > use payload/windows/meterpreter_reverse_tcp 
msf payload(meterpreter_reverse_tcp) > set LHOST 10.0.1.109
LHOST => 10.0.1.109
msf payload(meterpreter_reverse_tcp) > set LPORT 3377
LPORT => 3377
msf payload(meterpreter_reverse_tcp) > show options

Module options (payload/windows/meterpreter_reverse_tcp):

   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   EXITFUNC    process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   EXTENSIONS                   no        Comma-separate list of extensions to load
   EXTINIT                      no        Initialization strings for extensions
   LHOST       10.0.1.109       yes       The listen address
   LPORT       3377             yes       The listen port

msf payload(meterpreter_reverse_tcp) > to_handler
[*] Payload Handler Started as Job 0
[*] Started reverse TCP handler on 10.0.1.109:3377 
[*] Starting the payload handler...
msf payload(meterpreter_reverse_tcp) > 
```


